### PR TITLE
fix mime-type bug

### DIFF
--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,2 @@
 testDAYO
+PullReq出すテストだよ


### PR DESCRIPTION
I found mime-type bug.
Default magic_file can't take cognizance of right mime-type.
So I added magic_file option.